### PR TITLE
REMOVE default_attributes FROM TypographyP

### DIFF
--- a/lib/rbui/typography/typography_p.rb
+++ b/lib/rbui/typography/typography_p.rb
@@ -5,11 +5,5 @@ module RBUI
     def view_template(&)
       p(**attrs, &)
     end
-
-    private
-
-    def default_attrs
-      {}
-    end
   end
 end

--- a/lib/rbui/typography/typography_p.rb
+++ b/lib/rbui/typography/typography_p.rb
@@ -9,9 +9,7 @@ module RBUI
     private
 
     def default_attrs
-      {
-        class: "leading-7"
-      }
+      {}
     end
   end
 end

--- a/lib/rbui/typography/typography_p.rb
+++ b/lib/rbui/typography/typography_p.rb
@@ -10,7 +10,7 @@ module RBUI
 
     def default_attrs
       {
-        class: "leading-7 [&:not(:first-child)]:mt-6"
+        class: "leading-7"
       }
     end
   end


### PR DESCRIPTION
BEFORE
![image](https://github.com/user-attachments/assets/be13662e-acf3-4ca4-9fea-208ca37f1443)

AFTER
![image](https://github.com/user-attachments/assets/29b16a21-4d73-4bdf-9fd8-b938123305c1)

THE CODE
```
Tooltip(placement: "bottom") do
  TooltipTrigger do
    plain(helpers.lucide_icon("message-circle", class: "w-4 h-4 text-primary flex-none"))
  end

  TooltipContent(class: "flex flex-col gap-2 w-80 p-2") do
    TypographyP(weight: :medium) { "Comentário" }
    TypographyP { @supplier.approval_justification }

    div(class: "flex flex-row items-center gap-2") do
      plain(helpers.lucide_icon("user", size: 20, class: "text-slate-700"))
      TypographyP { @supplier.approval_user_email }
    end
  end
end
```