### PR TITLE
Make TailwindMerge::Merger instance a constant in the base class to allow for caching

### DIFF
--- a/lib/rbui/base.rb
+++ b/lib/rbui/base.rb
@@ -4,11 +4,13 @@ require "tailwind_merge"
 
 module RBUI
   class Base < Phlex::HTML
+    TAILWIND_MERGER = ::TailwindMerge::Merger.new
+
     attr_reader :attrs
 
     def initialize(**user_attrs)
       @attrs = mix(default_attrs, user_attrs)
-      @attrs[:class] = ::TailwindMerge::Merger.new.merge(@attrs[:class]) if @attrs[:class]
+      @attrs[:class] = TAILWIND_MERGER.merge(@attrs[:class]) if @attrs[:class]
     end
 
     if defined?(Rails) && Rails.env.development?

--- a/lib/rbui/base.rb
+++ b/lib/rbui/base.rb
@@ -4,7 +4,7 @@ require "tailwind_merge"
 
 module RBUI
   class Base < Phlex::HTML
-    TAILWIND_MERGER = ::TailwindMerge::Merger.new
+    TAILWIND_MERGER = ::TailwindMerge::Merger.new.freeze
 
     attr_reader :attrs
 


### PR DESCRIPTION
The current `Base` class implementation is initializing a new `TailwindMerge::Merger` object each time a new component is being rendered. This disables the caching mechanism implemented within `TailwindMerge` gem ([ref](https://github.com/gjtorikian/tailwind_merge/blob/main/lib/tailwind_merge.rb#L45-L47)).

This PR defines the `TailwindMerge::Merger` object as a constant in the `Base` class and re-uses it for all components. So, cached class merges can be re-used.

I benchmarked this change on one of my applications in the home page with the `main` and `tw-merge-const` branches and this is the average response time:
- `main` branch: 184.83ms
- `tw-merge-const` branch: 36.24ms