### PR TITLE
ADD BLOCK TO TEXTAREA

### DIFF
--- a/lib/rbui/textarea/textarea.rb
+++ b/lib/rbui/textarea/textarea.rb
@@ -7,8 +7,8 @@ module RBUI
       super(**attrs)
     end
 
-    def view_template
-      textarea(rows: @rows, **attrs)
+    def view_template(&)
+      textarea(rows: @rows, **attrs, &)
     end
 
     private

--- a/test/rbui/input_test.rb
+++ b/test/rbui/input_test.rb
@@ -12,4 +12,12 @@ class RBUI::InputTest < Minitest::Test
 
     assert_match(/Email/, output)
   end
+
+  def test_render_with_value
+    output = phlex_context do
+      RBUI.Input(type: "email", value: "Value")
+    end
+
+    assert_match(/Value/, output)
+  end
 end

--- a/test/rbui/input_test.rb
+++ b/test/rbui/input_test.rb
@@ -15,9 +15,9 @@ class RBUI::InputTest < Minitest::Test
 
   def test_render_with_value
     output = phlex_context do
-      RBUI.Input(type: "email", value: "Value")
+      RBUI.Input(type: "email", value: "user@email.com")
     end
 
-    assert_match(/Value/, output)
+    assert_match(/user@email.com/, output)
   end
 end

--- a/test/rbui/textarea_test.rb
+++ b/test/rbui/textarea_test.rb
@@ -12,4 +12,12 @@ class RBUI::TextareaTest < Minitest::Test
 
     assert_match(/Comment/, output)
   end
+
+  def test_render_with_value
+    output = phlex_context do
+      RBUI.Textarea(rows: 4) { "Value" }
+    end
+
+    assert_match(/Value/, output)
+  end
 end

--- a/test/rbui/textarea_test.rb
+++ b/test/rbui/textarea_test.rb
@@ -15,7 +15,7 @@ class RBUI::TextareaTest < Minitest::Test
 
   def test_render_with_value
     output = phlex_context do
-      RBUI.Textarea(rows: 4) { "Value" }
+      RBUI.Textarea { "Value" }
     end
 
     assert_match(/Value/, output)


### PR DESCRIPTION
The `textarea` tag doesn't have the `value` attribute like `input`...
To initialize a `textarea` tag with some value, it's necessary to open the block