### PR TITLE
FIX DOCS LINK

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bin/rails g rbui:install
 
 ## Documentation 📖
 
-Visit https://rbui.dev/docs to view the full documentation, including:
+Visit https://rbui.dev/docs/introduction to view the full documentation, including:
 
 - Detailed component guides
 - Themes


### PR DESCRIPTION
from https://rbui.dev/docs (broke)
to https://rbui.dev/docs/introduction (working)