### PR TITLE
bug: Fixes setting a custom namespace in initializer

### DIFF
--- a/lib/rbui.rb
+++ b/lib/rbui.rb
@@ -6,8 +6,6 @@ require "phlex"
 module RBUI
   extend Phlex::Kit
 
-  attr_accessor :namespace
-
   def self.setup
     yield self
     create_namespace_module if namespace
@@ -34,6 +32,14 @@ module RBUI
         source_module.respond_to?(name) || super(name, include_private)
       end
     end
+  end
+
+  def self.namespace
+    @namespace ||= nil
+  end
+
+  def self.namespace=(value)
+    @namespace = value
   end
 end
 

--- a/test/rbui/setup_test.rb
+++ b/test/rbui/setup_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RBUI::SetupTest < Minitest::Test
+  def setup
+    @original_namespace = RBUI.namespace
+  end
+
+  def teardown
+    RBUI.namespace = @original_namespace
+    Object.send(:remove_const, :UI) if Object.const_defined?(:UI)
+  end
+
+  def test_default_namespace
+    RBUI.setup {}
+
+    assert_nil RBUI.namespace
+    assert_kind_of RBUI::Base, RBUI::Button.new
+  end
+
+  def test_custom_namespace
+    RBUI.setup do |config|
+      config.namespace = "UI"
+    end
+
+    assert_equal "UI", RBUI.namespace
+    assert_equal RBUI::Base, UI::Base
+    assert_kind_of RBUI::Base, UI::Button.new
+  end
+end


### PR DESCRIPTION
There is a bug in the generated setup initializer which crashes the app on boot. If you uncomment the initializer, it will raise:

```
method_missing: undefined method `namespace=' for module RBUI (NoMethodError)
```

I believe this is caused by using `attr_accessor` instead of something like `mattr_accessor` (Rails) on the module, as `namespace` will be defined on an instance rather than the module itself. 

This PR adds `namespace` and `namespace=` methods to the module along with tests.